### PR TITLE
Add ApplicativeLocal and FunctorTell loggers

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,28 @@
+# tune this file as appropriate to your style!  see:
+# https://scalameta.org/scalafmt/docs/configuration.html
+
+version = 2.0.1
+
+maxColumn = 100
+
+continuationIndent.callSite = 2
+
+newlines {
+  sometimesBeforeColonInMethodReturnType = false
+}
+
+align {
+  arrowEnumeratorGenerator = false
+  ifWhileOpenParen = false
+  openParenCallSite = false
+  openParenDefnSite = false
+
+  tokens = ["%", "%%"]
+}
+
+docstrings = JavaDoc
+
+rewrite {
+  rules = [SortImports, RedundantBraces]
+  redundantBraces.maxLines = 1
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ stages:
   - name: release
     if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
 
-scala_version_213: &scala_version_213 "2.13.0"
+scala_version_213: &scala_version_213 "2.13.1"
 scala_version_212: &scala_version_212 "2.12.10"
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ stages:
   - name: release
     if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
 
-scala_version_213: &scala_version_213 "2.13.1"
+scala_version_213: &scala_version_213 "2.13.0"
 scala_version_212: &scala_version_212 "2.12.10"
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ libraryDependencies ++= Seq(
 
 ## Examples
 
-```tut
+```scala
 import io.chrisdavenport.log4cats.extras.LogMessage
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.chrisdavenport.log4cats.mtl._
@@ -49,5 +49,4 @@ def doFunctorTellThings[F[_]: Sync: FunctorTell[?[_], Chain[LogMessage]]]: F[Uni
     _ <- logger.info("Logging at end of safelyDoThings")
   } yield something
 }
-
 ```

--- a/README.md
+++ b/README.md
@@ -4,11 +4,50 @@
 
 ## Quick Start
 
-To use log4cats-mtl in an existing SBT project with Scala 2.11 or a later version, add the following dependencies to your
+To use log4cats-mtl in an existing SBT project with Scala 2.12 or a later version, add the following dependencies to your
 `build.sbt` depending on your needs:
 
 ```scala
 libraryDependencies ++= Seq(
   "io.chrisdavenport" %% "log4cats-mtl" % "<version>"
 )
+```
+
+## Examples
+
+```tut
+import io.chrisdavenport.log4cats.extras.LogMessage
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import io.chrisdavenport.log4cats.mtl._
+import cats._
+import cats.data._
+import cats.effect.Sync
+import cats.implicits._
+import cats.mtl._
+import cats.mtl.implicits._
+
+final case class TraceId(value: String)
+
+implicit val traceIdCtxEncoder: CtxEncoder[TraceId] = (traceId: TraceId) => Map("traceId" -> traceId.value)
+
+def doApplicativeLocalThings[F[_]: Sync: ApplicativeLocal[?[_], TraceId]]: F[Unit] = 
+  (for {
+    logger <- ApplicativeAskLogger.create[F, TraceId](Slf4jLogger.create[F])
+    _ <- logger.info("Logging at start of safelyDoThings").scope(TraceId("inner-id"))
+    something <- Sync[F].delay(println("I could do anything"))
+      .onError{case e => logger.error(e)("Something Went Wrong in safelyDoThings")}
+    _ <- logger.info("Logging at end of safelyDoThings")
+  } yield something).scope(TraceId("outter-id"))
+  
+def doFunctorTellThings[F[_]: Sync: FunctorTell[?[_], Chain[LogMessage]]]: F[Unit] = {
+  val logger = FunctorTellLogger[F, Chain]()
+
+  for {
+    _ <- logger.info("Logging at start of safelyDoThings")
+    something <- Sync[F].delay(println("I could do anything"))
+      .onError{case e => logger.error(e)("Something Went Wrong in safelyDoThings")}
+    _ <- logger.info("Logging at end of safelyDoThings")
+  } yield something
+}
+
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
 val log4catsV = "1.0.0"
 val catsMtlV = "0.7.0"
+val catsEffectV = "2.0.0"
 
 val kindProjectorV = "0.10.3"
 val betterMonadicForV = "0.3.1"
@@ -56,7 +57,11 @@ lazy val site = project.in(file("site"))
         "-Ywarn-unused:imports",
         "-Xlint:-missing-interpolator,_"
       ),
-      libraryDependencies += "com.47deg" %% "github4s" % "0.20.1",
+      libraryDependencies ++= Seq(
+        "com.47deg"         %% "github4s"       % "0.20.1",
+        "org.typelevel"     %% "cats-effect"    % catsEffectV,
+        "io.chrisdavenport" %% "log4cats-slf4j" % log4catsV
+      ),
       micrositePushSiteWith := GitHub4s,
       micrositeGithubToken := sys.env.get("GITHUB_TOKEN"),
       micrositeExtraMdFiles := Map(

--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,6 @@ val betterMonadicForV = "0.3.1"
 // Projects
 lazy val `log4cats-mtl` = crossProject(JSPlatform, JVMPlatform)
   .in(file("."))
-  .disablePlugins(MimaPlugin)
-  .enablePlugins(NoPublishPlugin)
   .settings(commonSettings)
 
 lazy val mtlJVM = `log4cats-mtl`.jvm

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ val log4catsV = "1.0.0"
 val catsMtlV = "0.7.0"
 val catsEffectV = "2.0.0"
 
-val kindProjectorV = "0.10.3"
+val kindProjectorV = "0.11.0"
 val betterMonadicForV = "0.3.1"
 
 
@@ -58,7 +58,6 @@ lazy val site = project.in(file("site"))
         "-Xlint:-missing-interpolator,_"
       ),
       libraryDependencies ++= Seq(
-        "com.47deg"         %% "github4s"       % "0.20.1",
         "org.typelevel"     %% "cats-effect"    % catsEffectV,
         "io.chrisdavenport" %% "log4cats-slf4j" % log4catsV
       ),
@@ -73,10 +72,10 @@ lazy val site = project.in(file("site"))
 
 // General Settings
 lazy val commonSettings = Seq(
-  scalaVersion := "2.13.0",
+  scalaVersion := "2.13.1",
   crossScalaVersions := Seq(scalaVersion.value, "2.12.10"),
 
-  addCompilerPlugin("org.typelevel" %  "kind-projector"     % kindProjectorV cross CrossVersion.binary),
+  addCompilerPlugin("org.typelevel" %  "kind-projector"     % kindProjectorV cross CrossVersion.full),
   addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % betterMonadicForV),
 
   libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,31 +1,21 @@
-import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
+import sbtcrossproject.CrossPlugin.autoImport.crossProject
 
-val catsV = "2.0.0"
-val catsEffectV = "2.0.0"
-val shapelessV = "2.3.3"
-val fs2V = "2.0.0"
-val http4sV = "0.21.0-M5"
-val circeV = "0.12.1"
-val doobieV = "0.8.2"
 val log4catsV = "1.0.0"
-val specs2V = "4.7.1"
+val catsMtlV = "0.7.0"
 
 val kindProjectorV = "0.10.3"
 val betterMonadicForV = "0.3.1"
 
 
-
 // Projects
-lazy val `log4cats-mtl` = project.in(file("."))
+lazy val `log4cats-mtl` = crossProject(JSPlatform, JVMPlatform)
+  .in(file("."))
   .disablePlugins(MimaPlugin)
   .enablePlugins(NoPublishPlugin)
-  .aggregate(core)
-
-lazy val core = project.in(file("core"))
   .settings(commonSettings)
-  .settings(
-    name := "log4cats-mtl"
-  )
+
+lazy val mtlJVM = `log4cats-mtl`.jvm
+lazy val mtlJS  = `log4cats-mtl`.js
 
 lazy val site = project.in(file("site"))
   .disablePlugins(MimaPlugin)
@@ -33,7 +23,7 @@ lazy val site = project.in(file("site"))
   .enablePlugins(MdocPlugin)
   .enablePlugins(NoPublishPlugin)
   .settings(commonSettings)
-  .dependsOn(core)
+  .dependsOn(mtlJVM)
   .settings{
     import microsites._
     Seq(
@@ -78,44 +68,15 @@ lazy val site = project.in(file("site"))
 
 // General Settings
 lazy val commonSettings = Seq(
-  scalaVersion := "2.13.1",
+  scalaVersion := "2.13.0",
   crossScalaVersions := Seq(scalaVersion.value, "2.12.10"),
 
-  addCompilerPlugin("org.typelevel" % "kind-projector" % kindProjectorV cross CrossVersion.binary),
+  addCompilerPlugin("org.typelevel" %  "kind-projector"     % kindProjectorV cross CrossVersion.binary),
   addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % betterMonadicForV),
 
   libraryDependencies ++= Seq(
-    "org.typelevel"               %% "cats-core"                  % catsV,
-    "org.typelevel"               %% "alleycats-core"             % catsV,
-
-    "org.typelevel"               %% "cats-effect"                % catsEffectV,
-
-    "com.chuusai"                 %% "shapeless"                  % shapelessV,
-
-    "co.fs2"                      %% "fs2-core"                   % fs2V,
-    "co.fs2"                      %% "fs2-io"                     % fs2V,
-
-    "org.http4s"                  %% "http4s-dsl"                 % http4sV,
-    "org.http4s"                  %% "http4s-blaze-server"        % http4sV,
-    "org.http4s"                  %% "http4s-blaze-client"        % http4sV,
-    "org.http4s"                  %% "http4s-circe"               % http4sV,
-
-    "io.circe"                    %% "circe-core"                 % circeV,
-    "io.circe"                    %% "circe-generic"              % circeV,
-    "io.circe"                    %% "circe-parser"               % circeV,
-
-    "org.tpolecat"                %% "doobie-core"                % doobieV,
-    "org.tpolecat"                %% "doobie-h2"                  % doobieV,
-    "org.tpolecat"                %% "doobie-hikari"              % doobieV,
-    "org.tpolecat"                %% "doobie-postgres"            % doobieV,
-    "org.tpolecat"                %% "doobie-specs2"              % doobieV       % Test,
-
-    "io.chrisdavenport"           %% "log4cats-core"              % log4catsV,
-    "io.chrisdavenport"           %% "log4cats-slf4j"             % log4catsV,
-    "io.chrisdavenport"           %% "log4cats-testing"           % log4catsV     % Test,
-
-    "org.specs2"                  %% "specs2-core"                % specs2V       % Test,
-    "org.specs2"                  %% "specs2-scalacheck"          % specs2V       % Test
+    "io.chrisdavenport" %% "log4cats-core" % log4catsV,
+    "org.typelevel"     %% "cats-mtl-core" % catsMtlV
   )
 )
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,3 +15,42 @@ libraryDependencies ++= Seq(
   "io.chrisdavenport" %% "log4cats-mtl" % "<version>"
 )
 ```
+
+## Examples
+
+```scala mdoc
+import io.chrisdavenport.log4cats.extras.LogMessage
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import io.chrisdavenport.log4cats.mtl._
+import cats._
+import cats.data._
+import cats.effect.Sync
+import cats.implicits._
+import cats.mtl._
+import cats.mtl.implicits._
+
+final case class TraceId(value: String)
+
+implicit val traceIdCtxEncoder: CtxEncoder[TraceId] = (traceId: TraceId) => Map("traceId" -> traceId.value)
+
+def doApplicativeLocalThings[F[_]: Sync: ApplicativeLocal[?[_], TraceId]]: F[Unit] = 
+  (for {
+    logger <- ApplicativeAskLogger.create[F, TraceId](Slf4jLogger.create[F])
+    _ <- logger.info("Logging at start of safelyDoThings").scope(TraceId("inner-id"))
+    something <- Sync[F].delay(println("I could do anything"))
+      .onError{case e => logger.error(e)("Something Went Wrong in safelyDoThings")}
+    _ <- logger.info("Logging at end of safelyDoThings")
+  } yield something).scope(TraceId("outter-id"))
+  
+def doFunctorTellThings[F[_]: Sync: FunctorTell[?[_], Chain[LogMessage]]]: F[Unit] = {
+  val logger = FunctorTellLogger[F, Chain]()
+
+  for {
+    _ <- logger.info("Logging at start of safelyDoThings")
+    something <- Sync[F].delay(println("I could do anything"))
+      .onError{case e => logger.error(e)("Something Went Wrong in safelyDoThings")}
+    _ <- logger.info("Logging at end of safelyDoThings")
+  } yield something
+}
+
+```

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,4 @@ addSbtPlugin("io.chrisdavenport" % "sbt-no-publish" % "0.1.0")
 
 addSbtPlugin("com.47deg" % "sbt-microsites" % "0.9.6")
 addSbtPlugin("org.scalameta" % "sbt-mdoc" % "1.3.2")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.5")

--- a/shared/src/main/scala/io/chrisdavenport/log4cats/mtl/ApplicativeAskLogger.scala
+++ b/shared/src/main/scala/io/chrisdavenport/log4cats/mtl/ApplicativeAskLogger.scala
@@ -1,0 +1,103 @@
+package io.chrisdavenport.log4cats.mtl
+
+import cats.FlatMap
+import cats.mtl.ApplicativeAsk
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import io.chrisdavenport.log4cats.SelfAwareStructuredLogger
+
+object ApplicativeAskLogger {
+
+  def unsafeCreate[F[_]: FlatMap: ApplicativeAsk[?[_], A], A: CtxEncoder](
+      logger: SelfAwareStructuredLogger[F]
+  ): SelfAwareStructuredLogger[F] =
+    new ApplicativeAskLogger(logger)
+
+  def create[F[_]: FlatMap: ApplicativeAsk[?[_], A], A: CtxEncoder](
+      logger: F[SelfAwareStructuredLogger[F]]
+  ): F[SelfAwareStructuredLogger[F]] =
+    logger.map(v => new ApplicativeAskLogger(v))
+
+}
+
+final class ApplicativeAskLogger[F[_]: FlatMap: ApplicativeAsk[?[_], A], A: CtxEncoder](
+    underlying: SelfAwareStructuredLogger[F]
+) extends SelfAwareStructuredLogger[F] {
+
+  override def trace(ctx: Map[String, String])(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.trace(ctx ++ local)(msg))
+
+  override def trace(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.trace(ctx ++ local, t)(msg))
+
+  override def debug(ctx: Map[String, String])(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.debug(ctx ++ local)(msg))
+
+  override def debug(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.debug(ctx ++ local, t)(msg))
+
+  override def info(ctx: Map[String, String])(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.info(ctx ++ local)(msg))
+
+  override def info(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.info(ctx ++ local, t)(msg))
+
+  override def warn(ctx: Map[String, String])(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.warn(ctx ++ local)(msg))
+
+  override def warn(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.warn(ctx ++ local, t)(msg))
+
+  override def error(ctx: Map[String, String])(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.error(ctx ++ local)(msg))
+
+  override def error(ctx: Map[String, String], t: Throwable)(msg: => String): F[Unit] =
+    withLocalCtx(local => underlying.error(ctx ++ local, t)(msg))
+
+  override def isTraceEnabled: F[Boolean] = underlying.isTraceEnabled
+  override def isDebugEnabled: F[Boolean] = underlying.isDebugEnabled
+  override def isInfoEnabled: F[Boolean] = underlying.isInfoEnabled
+  override def isWarnEnabled: F[Boolean] = underlying.isWarnEnabled
+  override def isErrorEnabled: F[Boolean] = underlying.isErrorEnabled
+
+  override def error(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.error(local)(message))
+
+  override def warn(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.warn(local)(message))
+
+  override def info(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.info(local)(message))
+
+  override def debug(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.debug(local)(message))
+
+  override def trace(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.trace(local)(message))
+
+  override def error(t: Throwable)(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.error(local, t)(message))
+
+  override def warn(t: Throwable)(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.warn(local, t)(message))
+
+  override def info(t: Throwable)(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.info(local, t)(message))
+
+  override def debug(t: Throwable)(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.debug(local, t)(message))
+
+  override def trace(t: Throwable)(message: => String): F[Unit] =
+    withLocalCtx(local => underlying.trace(local, t)(message))
+
+  @inline private def withLocalCtx[B](f: Map[String, String] => F[B]): F[B] =
+    ApplicativeAsk.ask.flatMap(a => f(CtxEncoder[A].encode(a)))
+}
+
+trait CtxEncoder[A] {
+  def encode(value: A): Map[String, String]
+}
+
+object CtxEncoder {
+  def apply[A](implicit ev: CtxEncoder[A]): CtxEncoder[A] = ev
+}

--- a/shared/src/main/scala/io/chrisdavenport/log4cats/mtl/FunctorTellLogger.scala
+++ b/shared/src/main/scala/io/chrisdavenport/log4cats/mtl/FunctorTellLogger.scala
@@ -1,0 +1,71 @@
+package io.chrisdavenport.log4cats.mtl
+
+import cats.Applicative
+import cats.mtl.FunctorTell
+import cats.syntax.applicative._
+import cats.syntax.option._
+import io.chrisdavenport.log4cats.SelfAwareLogger
+import io.chrisdavenport.log4cats.extras.{LogLevel, LogMessage}
+
+object FunctorTellLogger {
+
+  def apply[F[_]: Applicative: FunctorTell[?[_], G[LogMessage]], G[_]: Applicative](
+      traceEnabled: Boolean = true,
+      debugEnabled: Boolean = true,
+      infoEnabled: Boolean = true,
+      warnEnabled: Boolean = true,
+      errorEnabled: Boolean = true
+  ): SelfAwareLogger[F] =
+    new FunctorTellLogger[F, G](traceEnabled, debugEnabled, infoEnabled, warnEnabled, errorEnabled)
+
+}
+
+final class FunctorTellLogger[F[_]: Applicative, G[_]: Applicative](
+    traceEnabled: Boolean = true,
+    debugEnabled: Boolean = true,
+    infoEnabled: Boolean = true,
+    warnEnabled: Boolean = true,
+    errorEnabled: Boolean = true
+)(implicit FT: FunctorTell[F, G[LogMessage]])
+    extends SelfAwareLogger[F] {
+
+  override def isTraceEnabled: F[Boolean] = traceEnabled.pure[F]
+  override def isDebugEnabled: F[Boolean] = debugEnabled.pure[F]
+  override def isInfoEnabled: F[Boolean] = infoEnabled.pure[F]
+  override def isWarnEnabled: F[Boolean] = warnEnabled.pure[F]
+  override def isErrorEnabled: F[Boolean] = errorEnabled.pure[F]
+
+  override def trace(t: Throwable)(message: => String): F[Unit] =
+    build(traceEnabled, LogLevel.Trace, t.some, message)
+  override def trace(message: => String): F[Unit] =
+    build(traceEnabled, LogLevel.Trace, None, message)
+
+  override def debug(t: Throwable)(message: => String): F[Unit] =
+    build(debugEnabled, LogLevel.Debug, t.some, message)
+  override def debug(message: => String): F[Unit] =
+    build(debugEnabled, LogLevel.Debug, None, message)
+
+  override def info(t: Throwable)(message: => String): F[Unit] =
+    build(infoEnabled, LogLevel.Info, t.some, message)
+  override def info(message: => String): F[Unit] =
+    build(infoEnabled, LogLevel.Info, None, message)
+
+  override def warn(t: Throwable)(message: => String): F[Unit] =
+    build(warnEnabled, LogLevel.Warn, t.some, message)
+  override def warn(message: => String): F[Unit] =
+    build(warnEnabled, LogLevel.Warn, None, message)
+
+  override def error(t: Throwable)(message: => String): F[Unit] =
+    build(errorEnabled, LogLevel.Error, t.some, message)
+  override def error(message: => String): F[Unit] =
+    build(errorEnabled, LogLevel.Error, None, message)
+
+  @inline private def build(
+      enabled: Boolean,
+      level: LogLevel,
+      t: Option[Throwable],
+      message: => String
+  ): F[Unit] =
+    FT.tell(LogMessage(level, t, message).pure[G]).whenA(enabled)
+
+}


### PR DESCRIPTION
This PR adds two new loggers:

1) A logger that uses a value of `cats.mtl.ApplicativeLocal` as an additional MDC;
2) A logger that writes LogMessage entries into effect context using `cats.mtl.FunctorTell`.